### PR TITLE
nocancer2.js

### DIFF
--- a/mods/nocancer2.js
+++ b/mods/nocancer2.js
@@ -1,0 +1,1 @@
+delete elements.cancer;


### PR DESCRIPTION
A better yet more risky method of removing cancer. May cause game to crash, but prevents cancer from being created in the first place which is better opposed to removing cancer 1 tick after it's created.

It's also teeny tiny, just like noconfirm.js